### PR TITLE
Default to the ramcontroller that matches the current ROM

### DIFF
--- a/bizhawk-co-op/ramcontroller/Link to the Past.lua
+++ b/bizhawk-co-op/ramcontroller/Link to the Past.lua
@@ -1,3 +1,5 @@
+-- romname: Legend of Zelda, The [-] A Link to the Past
+
 local items = {
 	[0x5A] = 'Nothing',
 	[0x49] = 'Fighters Sword',

--- a/bizhawk-co-op/ramcontroller/Metroid Zero Mission.lua
+++ b/bizhawk-co-op/ramcontroller/Metroid Zero Mission.lua
@@ -1,3 +1,5 @@
+-- romname: Metroid [-] Zero Mission
+
 -- Mapping for the flags of each ability (little endian)
 local AbilityMap = {
 	--longbeam = 0

--- a/bizhawk-co-op/ramcontroller/Ocarina of Time.lua
+++ b/bizhawk-co-op/ramcontroller/Ocarina of Time.lua
@@ -1,3 +1,4 @@
+-- romname: OoTR
 
 console.log('------------------')
 local old_global_metatable = getmetatable(_G)


### PR DESCRIPTION
Each ramcontroller may provide a Lua pattern to match against the ROMs name (as provided by gameinfo.getromname()); the ramcontroller with the first matching pattern is used as the default.

The pattern is specified by a comment rather than a function or global variable since (a) it's slow to run all of the ramcontrollers on startup, and (b) the ramcontrollers may modify global state. A comment is also trivially backwards-compatible with any existing third-party ramcontrollers.